### PR TITLE
juno compatibility

### DIFF
--- a/crates/blockifier/src/blockifier/block.rs
+++ b/crates/blockifier/src/blockifier/block.rs
@@ -29,12 +29,12 @@ pub struct BlockInfo {
 
 #[derive(Clone, Debug)]
 pub struct GasPrices {
-    eth_l1_gas_price: NonZeroU128,       // In wei.
-    strk_l1_gas_price: NonZeroU128,      // In fri.
-    eth_l1_data_gas_price: NonZeroU128,  // In wei.
-    strk_l1_data_gas_price: NonZeroU128, // In fri.
-    eth_l2_gas_price: NonZeroU128,       // In wei.
-    strk_l2_gas_price: NonZeroU128,      // In fri.
+    pub eth_l1_gas_price: NonZeroU128,       // In wei.
+    pub strk_l1_gas_price: NonZeroU128,      // In fri.
+    pub eth_l1_data_gas_price: NonZeroU128,  // In wei.
+    pub strk_l1_data_gas_price: NonZeroU128, // In fri.
+    pub eth_l2_gas_price: NonZeroU128,       // In wei.
+    pub strk_l2_gas_price: NonZeroU128,      // In fri.
 }
 
 impl GasPrices {


### PR DESCRIPTION
Corresponding changes for NethermindEth/juno#2115

Changes `GasPrices` fields to be public.