### PR TITLE
fix: function idx

### DIFF
--- a/crates/blockifier/src/execution/contract_class.rs
+++ b/crates/blockifier/src/execution/contract_class.rs
@@ -649,11 +649,9 @@ impl NativeContractClassV1Inner {
         // function name is what is used by Cairo Native to lookup the function.
         // Therefore it's not enough to know the function index and we need enrich the contract
         // entry point with FunctionIds from SierraProgram.
-        let lookup_fid: HashMap<usize, &FunctionId> =
-            HashMap::from_iter(sierra_program.funcs.iter().enumerate().map(|(idx, func)| {
-                // This exception should never occur as the id is also in [SierraContractClass]
-                (idx, &func.id)
-            }));
+        let lookup_fid: HashMap<usize, &FunctionId> = HashMap::from_iter(
+            sierra_program.funcs.iter().enumerate().map(|(idx, func)| (idx, &func.id)),
+        );
 
         Ok(NativeContractClassV1Inner {
             executor,

--- a/crates/blockifier/src/execution/contract_class.rs
+++ b/crates/blockifier/src/execution/contract_class.rs
@@ -650,10 +650,9 @@ impl NativeContractClassV1Inner {
         // Therefore it's not enough to know the function index and we need enrich the contract
         // entry point with FunctionIds from SierraProgram.
         let lookup_fid: HashMap<usize, &FunctionId> =
-            HashMap::from_iter(sierra_program.funcs.iter().map(|fid| {
+            HashMap::from_iter(sierra_program.funcs.iter().enumerate().map(|(idx, func)| {
                 // This exception should never occur as the id is also in [SierraContractClass]
-                let id: usize = fid.id.id.try_into().expect("function id exceeds usize");
-                (id, &fid.id)
+                (idx, &func.id)
             }));
 
         Ok(NativeContractClassV1Inner {


### PR DESCRIPTION
Use the proper function id in the lookup mapping, since `function_idx` it's just the order of function in the sierra program and function.id.id is `u64` used to be based on an hash (of size 64) of the name of the function - so that was the original cause there. So to be more convenient it's better to use direct order of function instead of converting types 